### PR TITLE
Make this plugin available as an API via JitPack

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-library`
+    `maven-publish`
     id("com.github.johnrengelman.shadow") version "8.1.1"
 }
 
@@ -45,3 +46,33 @@ tasks {
     }
 }
 
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            groupId = project.group.toString()
+            artifactId = project.name
+            version = project.version.toString()
+
+            from(components["java"])
+
+            pom {
+                name.set(project.name)
+                description.set("TimedPerms, plugin to implements in-game time temporary permission using LuckPerms.")
+                url.set("https://github.com/okocraft/timedperms")
+
+                licenses {
+                    license {
+                        name.set("GNU General Public License, Version 3.0")
+                        url.set("https://www.gnu.org/licenses/gpl-3.0.txt")
+                    }
+                }
+
+                scm {
+                    connection.set("scm:git:https://github.com/okocraft/timedperms.git")
+                    developerConnection.set("scm:git:git@github.com:okocraft/timedperms.git")
+                    url.set("https://github.com/okocraft/timedperms")
+                }
+            }
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,8 +4,6 @@ plugins {
     id("com.github.johnrengelman.shadow") version "8.1.1"
 }
 
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(17))
-
 group = "net.okocraft"
 version = "1.0.0"
 
@@ -24,6 +22,13 @@ dependencies {
 
     implementation("com.github.siroshun09.configapi:configapi-yaml:4.6.3")
     implementation("com.github.siroshun09.translationloader:translationloader:2.0.2")
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+        vendor.set(JvmVendorSpec.ADOPTIUM)
+    }
 }
 
 tasks {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,4 +5,8 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.4.0"
+}
+
 rootProject.name = "timedperms"


### PR DESCRIPTION
https://jitpack.io/#okocraft/TimedPerms

NOTE; [`foojay-resolver-convention`](https://github.com/gradle/foojay-toolchains) is used for downloading Java 17 in JitPack. In default, JitPack uses Java 8 so this project cannot be built.