### PR TITLE
fix crashes and placeholder argument parsing logic

### DIFF
--- a/src/main/java/net/okocraft/timedperms/Main.java
+++ b/src/main/java/net/okocraft/timedperms/Main.java
@@ -104,18 +104,10 @@ public class Main extends JavaPlugin implements Listener {
     }
 
     public static Path getJarPath() {
-        String path = Main.class.getProtectionDomain().getCodeSource().getLocation().getPath();
-        Path jarFilePath;
         try {
-            // for linux.
-            jarFilePath = Paths.get(path);
-        } catch (InvalidPathException e) {
-            // for windows.
-            if (path.startsWith("/")) {
-                path = path.substring(1);
-            }
-            jarFilePath = Paths.get(path);
+            return Paths.get(Main.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
-        return jarFilePath;
     }
 }

--- a/src/main/java/net/okocraft/timedperms/command/TimedPermsCommand.java
+++ b/src/main/java/net/okocraft/timedperms/command/TimedPermsCommand.java
@@ -208,6 +208,9 @@ public class TimedPermsCommand implements CommandExecutor, TabExecutor {
 
     private static String toString(PermissionNode node) {
         ContextSet contexts = node.getContexts();
+        if (contexts.isEmpty()) {
+            return node.getPermission();
+        }
         StringBuilder sb = new StringBuilder();
         contexts.forEach(c -> sb.append(c.getKey()).append("=").append(c.getValue()).append(","));
         return node.getPermission() + "(" + sb.substring(0, sb.length() - 1) + ")";

--- a/src/main/java/net/okocraft/timedperms/config/CommandExecutionSerializer.java
+++ b/src/main/java/net/okocraft/timedperms/config/CommandExecutionSerializer.java
@@ -32,10 +32,10 @@ public class CommandExecutionSerializer implements ConfigurationSerializer<Comma
         if (!placeholderRequirement.regex().isEmpty()) {
             config.set("placeholder-requirement.regex", placeholderRequirement.regex());
         }
-        if (placeholderRequirement.moreThan() == Double.MAX_VALUE) {
+        if (placeholderRequirement.moreThan() != Double.MAX_VALUE) {
             config.set("placeholder-requirement.more-than", placeholderRequirement.moreThan());
         }
-        if (placeholderRequirement.lessThan() == Double.MIN_VALUE) {
+        if (placeholderRequirement.lessThan() != Double.MIN_VALUE) {
             config.set("placeholder-requirement.less-than", placeholderRequirement.lessThan());
         }
         if (!placeholderRequirement.commandsOnDenied().isEmpty()) {

--- a/src/main/java/net/okocraft/timedperms/placeholderapi/Placeholder.java
+++ b/src/main/java/net/okocraft/timedperms/placeholderapi/Placeholder.java
@@ -52,13 +52,14 @@ public class Placeholder extends PlaceholderExpansion {
     }
 
     public int getSecondsFromArgs(OfflinePlayer context, String[] args) {
-        int permissionIndex = -1;
+        int firstContextIndex = -1;
         for (int i = 0; i < args.length; i++) {
-            permissionIndex = i - 1;
             if (args[i].contains("=")) {
+                firstContextIndex = i;
                 break;
             }
         }
+        int permissionIndex = firstContextIndex != -1 ? firstContextIndex - 1 : args.length - 1;
         if (permissionIndex < 0) {
             return -1;
         }
@@ -77,7 +78,7 @@ public class Placeholder extends PlaceholderExpansion {
             }
         }
 
-        if (!offlinePlayer.hasPlayedBefore()) {
+        if (offlinePlayer == null || !offlinePlayer.hasPlayedBefore()) {
             return -1;
         }
         LocalPlayer localPlayer = LocalPlayerFactory.get(offlinePlayer.getUniqueId());


### PR DESCRIPTION
- fixed StringIndexOutOfBoundsException when showing or modifying permission nodes without contexts
- fixed inverted conditional logic in command execution serializer for placeholder requirements
- fixed argument index calculation for placeholders when no contexts are provided, and added null check for offline player context
- fixed jar path resolution to support server installation directories containing spaces